### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ import usePopper from 'use-popper';
 import { useHover } from 'use-events';
 
 function Tooltip(props) {
-  const { referrence, popper, arrow } = usePopper({ placement: 'bottom' });
+  const { reference, popper, arrow } = usePopper({ placement: 'bottom' });
   const [active, bind] = useHover();
 
   return (
     <div>
-      <button ref={referrence.ref} {...bind}>
+      <button ref={reference.ref} {...bind}>
         hover me
       </button>
       {active && (

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,10 @@ function usePopper<R = HTMLElement, P = HTMLElement, A = HTMLElement>({
     reference: {
       ref: referenceRef,
     },
-    referrence: { // For backwards compatibility
+    /**
+     * @deprecated Due to typo. Use `reference` instead.
+     */
+    referrence: {
       ref: referenceRef,
     },
     popper: {


### PR DESCRIPTION
Further to changes added in https://github.com/sandiiarov/use-popper/pull/23

- Fixes typo in docs
- Adds a `@deprecated` annotation for jsdoc and IDE integration