### PR TITLE
Add option to pass parentRef to use-popper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ function usePopper<T, R = HTMLElement, P = HTMLElement, A = HTMLElement>({
   positionFixed = false,
   eventsEnabled = true,
   modifiers = {},
-}: Popper, parentReferenceNode: React.RefObject<T>) {
+}: Popper, parentReferenceNode?: React.RefObject<T>) {
   const popperInstance = React.useRef<PopperJS>(null);
   const [popperStyles, updatePopperState] = usePopperState(placement);
   const [referenceNode, referenceRef] = useCallbackRef<R>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,12 @@ export interface Popper {
   modifiers?: PopperJS.Modifiers;
 }
 
-function usePopper<R = HTMLElement, P = HTMLElement, A = HTMLElement>({
+function usePopper<T, R = HTMLElement, P = HTMLElement, A = HTMLElement>({
   placement = 'bottom',
   positionFixed = false,
   eventsEnabled = true,
   modifiers = {},
-}: Popper) {
+}: Popper, parentReferenceNode: React.RefObject<T>) {
   const popperInstance = React.useRef<PopperJS>(null);
   const [popperStyles, updatePopperState] = usePopperState(placement);
   const [referenceNode, referenceRef] = useCallbackRef<R>();
@@ -28,10 +28,10 @@ function usePopper<R = HTMLElement, P = HTMLElement, A = HTMLElement>({
       popperInstance.current.destroy();
     }
 
-    if (referenceNode === null || popperNode === null) return;
+    if (!(referenceNode || parentReferenceNode) || !popperNode) return;
 
     // @ts-ignore
-    popperInstance.current = new PopperJS(referenceNode, popperNode, {
+    popperInstance.current = new PopperJS(referenceNode || parentReferenceNode, popperNode, {
       placement,
       positionFixed,
       modifiers: {
@@ -63,6 +63,7 @@ function usePopper<R = HTMLElement, P = HTMLElement, A = HTMLElement>({
     placement,
     positionFixed,
     modifiers,
+    parentReferenceNode
   ]);
 
   React.useEffect(() => {
@@ -80,7 +81,7 @@ function usePopper<R = HTMLElement, P = HTMLElement, A = HTMLElement>({
       popperInstance.current.scheduleUpdate();
     }
   }, [popperInstance]);
-  
+
   return {
     reference: {
       ref: referenceRef,


### PR DESCRIPTION
## Issue
The current implementation gives limited freedom to attach popper to a specific DOM node. The current implementation requires the reference element to reside in the exact same component.

## Proposed solution
This PR (PoC) allows passing a custom reference node where `popper` should attach to.

### Example
Please keep in mind this is pseudo code, explanatory only.

**ParentComponent.ts**
```
// Parent component where popper.js should attach to.

const ParentComponent: React.FC = (): React.ReactElement => {
    const tooltipRef = useRef();

    return (
        <div ref={tooltipRef}>
            {/* Other contents */}
            <Tooltip
                parentReference={tooltipRef}
                placement={Position.TOP}
            >
                <div>PopperTooltip!</div>
            </Tooltip>
        </div>
    );
};
```

**Tooltip.ts**
```
const Tooltip: React.FC<props> = ({children, placement, parentReference}): React.ReactElement => {
    const {popper, arrow} = usePopper({placement}, parentReference.current);

    return (
        <div
             data-placement={popper.placement}
             ref={popper.ref as React.RefObject<HTMLDivElement>}
             style={popper.styles}
        >
            {children}
            <div
                className={componentName('arrow')}
                ref={arrow.ref as React.RefObject<HTMLDivElement>}
                style={arrow.styles}
            />
        </div>
    );
};
```