### PR TITLE
Add repository to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "use-popper",
   "version": "1.1.6",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sandiiarov/use-popper.git"
+  },
   "scripts": {
     "tsc": "tsc --noEmit",
     "build": "pack build"


### PR DESCRIPTION
## The problem

I could not find the link to this repository from the package details on npmjs.com. I like to be able to review possible dependencies before I install them, so I can assess whether it is something I want to depend on, and weigh up alternatives other than from metrics like download count.

Turns out, that I do want to use this over the alternatives, and I'd like to be able to easily find my way back here in case I have anything to contribute in future, or to be able to see what changed between versions before upgrading, etc.

## What this PR does

- [x] adds your repository details to package.json